### PR TITLE
Add support for py 3.8-3.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+## [Version 1.2.1](https://github.com/dataiku/dss-plugin-google-cloud-nlp/releases/tag/v1.2.1) - Support release - 2023-04
+
+- Added support for Python 3.8-3.11
+
+## [Version 1.2.0](https://github.com/dataiku/dss-plugin-google-cloud-nlp/releases/tag/v1.2.0) - Bugfix release - 2022-10
+
+- Preserve zero values returned by the API
+
+## [Version 1.0.1](https://github.com/dataiku/dss-plugin-google-cloud-nlp/releases/tag/v1.0.1) - Version release - 2020-10
+
+- Enhance UX: move some parameters from hidden state in "Advanced" to "Configuration"
+- Bump code-env requirements to latest versions
+- Increase language coverage for Sentiment Analysis API to cover latest changes
+- Add unit tests for the `api_parallelizer` module
+
+## [Version 1.0.0](https://github.com/dataiku/dss-plugin-google-cloud-nlp/releases/tag/v1.0.0) - Initial release - 2020-05
+
+- Initial release

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2020 Dataiku
+   Copyright 2020-2023 Dataiku
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/code-env/python/desc.json
+++ b/code-env/python/desc.json
@@ -1,15 +1,15 @@
 {
-	"acceptedPythonInterpreters": [
-		"PYTHON35",
-		"PYTHON36",
-		"PYTHON37",
+    "acceptedPythonInterpreters": [
+        "PYTHON35",
+        "PYTHON36",
+        "PYTHON37",
         "PYTHON38",
         "PYTHON39",
         "PYTHON310",
         "PYTHON311"
     ],
     "corePackagesSet": "AUTO",
-	"forceConda": false,
-	"installCorePackages": true,
-	"installJupyterSupport": false
+    "forceConda": false,
+    "installCorePackages": true,
+    "installJupyterSupport": false
 }

--- a/code-env/python/desc.json
+++ b/code-env/python/desc.json
@@ -2,8 +2,13 @@
 	"acceptedPythonInterpreters": [
 		"PYTHON35",
 		"PYTHON36",
-		"PYTHON37"
-	],
+		"PYTHON37",
+        "PYTHON38",
+        "PYTHON39",
+        "PYTHON310",
+        "PYTHON311"
+    ],
+    "corePackagesSet": "AUTO",
 	"forceConda": false,
 	"installCorePackages": true,
 	"installJupyterSupport": false

--- a/code-env/python/spec/requirements.txt
+++ b/code-env/python/spec/requirements.txt
@@ -1,4 +1,5 @@
-grpcio==1.32.0
+grpcio==1.39.0; python_version <= '3.6'
+grpcio==1.54.0; python_version > '3.6'
 google-api-python-client==1.12.3
 google-cloud-language==1.3.0
 tqdm==4.50.1

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "google-cloud-nlp",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "meta": {
         "label": "Google Cloud NLP",
         "category": "Natural Language Processing",


### PR DESCRIPTION
[sc-132091]

- Added Python 3.7, 3.8, 3.9, 3.10, 3.11
- Added changelog
- For `grpcio`: bump to `1.39.0` for `<=3.6`, use `1.54.0` for `>3.6`

